### PR TITLE
Fixes a bug in the d7_og_user_membership migration and avoids altering migration source properties 

### DIFF
--- a/og_migrate/migrations/d6_og_admin_role.yml
+++ b/og_migrate/migrations/d6_og_admin_role.yml
@@ -9,16 +9,13 @@ source:
 process:
   id: id
   label:
-    -
       plugin: default_value
       default_value: 'administrator'
   weight:
-    -
       plugin: default_value
       default_value: 0
   is_admin: is_admin
   group_id:
-    -
       plugin: default_value
       default_value: 0
   group_type: constants/entity_type

--- a/og_migrate/migrations/d6_og_admin_role.yml
+++ b/og_migrate/migrations/d6_og_admin_role.yml
@@ -9,15 +9,15 @@ source:
 process:
   id: id
   label:
-      plugin: default_value
-      default_value: 'administrator'
+    plugin: default_value
+    default_value: 'administrator'
   weight:
-      plugin: default_value
-      default_value: 0
+    plugin: default_value
+    default_value: 0
   is_admin: is_admin
   group_id:
-      plugin: default_value
-      default_value: 0
+    plugin: default_value
+    default_value: 0
   group_type: constants/entity_type
   group_bundle:
     -

--- a/og_migrate/migrations/d6_og_audience.yml
+++ b/og_migrate/migrations/d6_og_audience.yml
@@ -12,8 +12,8 @@ process:
   entity_type: constants/entity_type
   entity_bundle: type
   settings:
-      plugin: default_value
-      default_value: ~
+    plugin: default_value
+    default_value: ~
 destination:
   plugin: og_field
 migration_dependencies:

--- a/og_migrate/migrations/d6_og_audience.yml
+++ b/og_migrate/migrations/d6_og_audience.yml
@@ -12,7 +12,6 @@ process:
   entity_type: constants/entity_type
   entity_bundle: type
   settings:
-    -
       plugin: default_value
       default_value: ~
 destination:

--- a/og_migrate/migrations/d6_og_node_membership.yml
+++ b/og_migrate/migrations/d6_og_node_membership.yml
@@ -28,12 +28,10 @@ process:
       message: 'Missing group content node'
   entity_type: constants/entity_type
   language:
-    -
       plugin: default_value
       source: og_language
       default_value: und
   field_name:
-    -
       plugin: default_value
       default_value: og_audience
 destination:

--- a/og_migrate/migrations/d6_og_node_membership.yml
+++ b/og_migrate/migrations/d6_og_node_membership.yml
@@ -28,12 +28,12 @@ process:
       message: 'Missing group content node'
   entity_type: constants/entity_type
   language:
-      plugin: default_value
-      source: og_language
-      default_value: und
+    plugin: default_value
+    source: og_language
+    default_value: und
   field_name:
-      plugin: default_value
-      default_value: og_audience
+    plugin: default_value
+    default_value: og_audience
 destination:
   plugin: og_entity_membership
 migration_dependencies:

--- a/og_migrate/migrations/d6_og_user_membership.yml
+++ b/og_migrate/migrations/d6_og_user_membership.yml
@@ -38,17 +38,17 @@ process:
       method: row
       message: 'Missing content type'
   state:
-      plugin: static_map
-      source: is_active
-      map:
-        0: pending
-        1: active
+    plugin: static_map
+    source: is_active
+    map:
+      0: pending
+      1: active
   roles: roles
   created: created
   language:
-      plugin: default_value
-      source: og_language
-      default_value: und
+    plugin: default_value
+    source: og_language
+    default_value: und
 destination:
   plugin: entity:og_membership
 migration_dependencies:

--- a/og_migrate/migrations/d6_og_user_membership.yml
+++ b/og_migrate/migrations/d6_og_user_membership.yml
@@ -38,7 +38,6 @@ process:
       method: row
       message: 'Missing content type'
   state:
-    -
       plugin: static_map
       source: is_active
       map:
@@ -47,7 +46,6 @@ process:
   roles: roles
   created: created
   language:
-    -
       plugin: default_value
       source: og_language
       default_value: und

--- a/og_migrate/migrations/d7_og_entity_membership.yml
+++ b/og_migrate/migrations/d7_og_entity_membership.yml
@@ -5,8 +5,26 @@ migration_tags:
 source:
   plugin: d7_og_membership
 process:
-  target_id: gid
-  entity_id: etid
+  # Currently only supports node groups
+  target_id:
+    -
+      plugin: migration_lookup
+      migration: d7_node
+      source: gid
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Membership group is missing'
+  # Currently only supports node entities
+  entity_id:
+    -
+      plugin: migration_lookup
+      migration: d7_node
+      source: etid
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Membership entity is missing'
   entity_type:
     -
       plugin: og_entity_type_exists
@@ -32,9 +50,9 @@ destination:
 migration_dependencies:
   required:
     - d7_user
+    - d7_node
     - d7_og_role
     - d7_og_group
     - d7_og_field_instance
   optional:
-    - d7_node
     - d7_taxonomy_term

--- a/og_migrate/migrations/d7_og_entity_membership.yml
+++ b/og_migrate/migrations/d7_og_entity_membership.yml
@@ -38,12 +38,11 @@ process:
   # property and migration lookups only check source properties beacuse. We
   # assume that everything will be mapped to og_audience.
   field_name:
-    -
-      plugin: static_map
-      source: field_name
-      map:
-        og_group_ref: og_audience
-        default: og_audience
+    plugin: static_map
+    source: field_name
+    map:
+      og_group_ref: og_audience
+      default: og_audience
   language: language
 destination:
   plugin: og_entity_membership

--- a/og_migrate/migrations/d7_og_field_instance.yml
+++ b/og_migrate/migrations/d7_og_field_instance.yml
@@ -19,7 +19,6 @@ process:
   entity_type: entity_type
   entity_bundle: bundle
   settings:
-    -
       plugin: skip_on_empty
       method: process
 destination:

--- a/og_migrate/migrations/d7_og_field_instance.yml
+++ b/og_migrate/migrations/d7_og_field_instance.yml
@@ -19,8 +19,8 @@ process:
   entity_type: entity_type
   entity_bundle: bundle
   settings:
-      plugin: skip_on_empty
-      method: process
+    plugin: skip_on_empty
+    method: process
 destination:
   plugin: og_field
 migration_dependencies:

--- a/og_migrate/migrations/d7_og_membership_type.yml
+++ b/og_migrate/migrations/d7_og_membership_type.yml
@@ -6,11 +6,11 @@ source:
   plugin: d7_og_membership_type
 process:
   type:
-      plugin: static_map
-      source: name
-      bypass: true
-      map:
-        og_membership_type_default: default
+    plugin: static_map
+    source: name
+    bypass: true
+    map:
+      og_membership_type_default: default
   name: description
   description: description
   status: status

--- a/og_migrate/migrations/d7_og_membership_type.yml
+++ b/og_migrate/migrations/d7_og_membership_type.yml
@@ -6,7 +6,6 @@ source:
   plugin: d7_og_membership_type
 process:
   type:
-    -
       plugin: static_map
       source: name
       bypass: true

--- a/og_migrate/migrations/d7_og_role.yml
+++ b/og_migrate/migrations/d7_og_role.yml
@@ -32,7 +32,6 @@ process:
   group_id: gid
   # @todo How can this be detected?
   is_admin:
-    -
       plugin: static_map
       source: name
       bypass: false
@@ -42,7 +41,6 @@ process:
         administrator: true
       default_value: false
   role_type:
-    -
       plugin: static_map
       source: name
       bypass: false

--- a/og_migrate/migrations/d7_og_role.yml
+++ b/og_migrate/migrations/d7_og_role.yml
@@ -32,23 +32,23 @@ process:
   group_id: gid
   # @todo How can this be detected?
   is_admin:
-      plugin: static_map
-      source: name
-      bypass: false
-      map:
-        member: false
-        'non-member': false
-        administrator: true
-      default_value: false
+    plugin: static_map
+    source: name
+    bypass: false
+    map:
+      member: false
+      'non-member': false
+      administrator: true
+    default_value: false
   role_type:
-      plugin: static_map
-      source: name
-      bypass: false
-      map:
-        member: required
-        'non-member': required
-        administrator: required
-      default_value: standard
+    plugin: static_map
+    source: name
+    bypass: false
+    map:
+      member: required
+      'non-member': required
+      administrator: required
+    default_value: standard
   permissions: permissions
 destination:
   plugin: entity:og_role

--- a/og_migrate/migrations/d7_og_user_membership.yml
+++ b/og_migrate/migrations/d7_og_user_membership.yml
@@ -40,7 +40,14 @@ process:
       plugin: migration_lookup
       migration: d7_og_role
       source: roles
-  state: state
+  state:
+    -
+      plugin: static_map
+      source: state
+      map:
+        1: active
+        2: pending
+        3: blocked
   created: created
   language: language
 destination:

--- a/og_migrate/migrations/d7_og_user_membership.yml
+++ b/og_migrate/migrations/d7_og_user_membership.yml
@@ -45,18 +45,17 @@ process:
       method: row
       message: 'Entity type is missing'
   roles:
-    -
       plugin: migration_lookup
       migration: d7_og_role
       source: roles
   state:
-    -
       plugin: static_map
       source: state
       map:
         1: active
         2: pending
         3: blocked
+      default_value: 1
   created: created
   language: language
 destination:

--- a/og_migrate/migrations/d7_og_user_membership.yml
+++ b/og_migrate/migrations/d7_og_user_membership.yml
@@ -45,17 +45,17 @@ process:
       method: row
       message: 'Entity type is missing'
   roles:
-      plugin: migration_lookup
-      migration: d7_og_role
-      source: roles
+    plugin: migration_lookup
+    migration: d7_og_role
+    source: roles
   state:
-      plugin: static_map
-      source: state
-      map:
-        1: active
-        2: pending
-        3: blocked
-      default_value: 1
+    plugin: static_map
+    source: state
+    map:
+      1: active
+      2: pending
+      3: blocked
+    default_value: 1
   created: created
   language: language
 destination:

--- a/og_migrate/migrations/d7_og_user_membership.yml
+++ b/og_migrate/migrations/d7_og_user_membership.yml
@@ -25,7 +25,16 @@ process:
       plugin: skip_on_empty
       method: row
       message: 'User uid is missing'
-  entity_id: gid
+  # Currently only supports node entities
+  entity_id:
+    -
+      plugin: migration_lookup
+      migration: d7_node
+      source: gid
+    -
+      plugin: skip_on_empty
+      method: row
+      message: 'Membership group is missing'
   entity_type:
     -
       plugin: og_entity_type_exists

--- a/og_migrate/og_migrate.module
+++ b/og_migrate/og_migrate.module
@@ -44,14 +44,5 @@ function og_migrate_migrate_prepare_row(Row $row, MigrateSourceInterface $source
         throw new MigrateSkipRowException('the og_membership_request is auto-created in the default group membership type');
       }
     }
-
-    $field_migrations = [
-      'd7_field_instance',
-      'd7_field_instance_per_view_mode',
-      'd7_field_instance_per_form_display',
-    ];
-    if (in_array($plugin_id, $field_migrations)) {
-      $row->setSourceProperty('bundle', $new_default_bundle);
-    }
   }
 }

--- a/og_migrate/og_migrate.services.yml
+++ b/og_migrate/og_migrate.services.yml
@@ -1,0 +1,5 @@
+services:
+  og_migrate.subscriber:
+    class: Drupal\og_migrate\EventSubscriber\OgMigratePreSaveSubscriber
+    tags:
+      - {name: event_subscriber}

--- a/og_migrate/src/EventSubscriber/OgMigratePreSaveSubscriber.php
+++ b/og_migrate/src/EventSubscriber/OgMigratePreSaveSubscriber.php
@@ -30,8 +30,8 @@ class OgMigratePreSaveSubscriber implements EventSubscriberInterface {
 
     $field_migrations = [
       'd7_field_instance',
-      'd7_field_instance_per_view_mode',
-      'd7_field_instance_per_form_display',
+      'd7_field_formatter_settings',
+      'd7_field_instance_widget_settings',
     ];
 
     if (in_array($plugin_id, $field_migrations)) {

--- a/tests/src/Kernel/Migrate/OgUserMembershipD7MigrateTest.php
+++ b/tests/src/Kernel/Migrate/OgUserMembershipD7MigrateTest.php
@@ -106,6 +106,7 @@ class OgUserMembershipD7MigrateTest extends MigrateDrupal7TestBase {
     $this->assertNotNull($membership);
     $this->assertTrue($membership->hasRole('node-test_content_type-administrator'), 'User 2 has administrator role.');
     $this->assertTrue($membership->hasRole('node-test_content_type-content-creator'), 'User 2 has content-creator role.');
+    $this->assertTrue($membership->isActive());
   }
 
 }


### PR DESCRIPTION
This pull request fixes a bug in the d7_og_user_membership, which caused the status to be imported as integers instead of strings.

It also moves some of the code from og_migrate_migrate_prepare_row to OgMigratePreSaveSubscriber to allow altering migration destination properties instead of having to alter source properties.

Note: I removed most of the old code in OgMigratePreSaveSubscriber as it seemed outdated and unused since it was not declared within a service.yml. I am not sure what purpose that code served, so feel free to put it back in if needed.